### PR TITLE
Rename week 1 workshop to remove focus on Marauroa

### DIFF
--- a/01-building.Rmd
+++ b/01-building.Rmd
@@ -1,8 +1,6 @@
 # (PART) Weekly Workshops {-}
 
-# Marauroa {#building}
-
-Marauroa is an open source *framework* and engine to develop games. It provides a simple way of creating games on a portable and robust server architecture. Marauroa manages the client server communication and provides an object orientated view of the world for game developers. It further handles database access in a transparent way to store player accounts, character progress and the state of the world.
+# Building and Testing Systems {#building}
 
 ## Introduction {#Introduction}
 
@@ -16,6 +14,8 @@ In this workshop, we will be building and testing Marauroa. We will look at some
 * Run a piece of software consisting of multiple distributed subsystems.
 
 In this, and some later workshops, we'll be working with the code of the *Marauroa games engine* for constructing on-line multi-player games.
+
+Marauroa is an open source *framework* and engine to develop games. It provides a simple way of creating games on a portable and robust server architecture. Marauroa manages the client server communication and provides an object orientated view of the world for game developers. It further handles database access in a transparent way to store player accounts, character progress and the state of the world.
 
 You should already have begun to practice some of these skills, through the GitLab Access Check activity.
 In this workshop, we will build on that activity to carry out these basic skills on a large open source software system.  During the workshop, you will:


### PR DESCRIPTION
The heading for this page makes it appear as though Marauroa is the main thing being learnt about in this
workshop, when in fact it's just an old system we happen to be using to teach other things.  I made some
small edits to change the focus back to the skill being developed, rather than the (incidental) tool we use
for teaching.

(This is also a simple change for me to suggest to start to get used to working with Bookdown and
suggesting changes for your main copy of the text.  Feel free to ignore it if you want.)